### PR TITLE
Added Rate Limiting Middleware to Prevent Request Abuse(issue #3)

### DIFF
--- a/server/internal/middleware/ratelimiter.go
+++ b/server/internal/middleware/ratelimiter.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type RateLimiter struct {
+	requests map[string]int
+	mu        sync.Mutex
+	resetTime time.Time
+	limit     int
+	window    time.Duration
+}
+
+func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
+	return &RateLimiter{
+		requests: make(map[string]int),
+		resetTime: time.Now().Add(window),
+		limit:     limit,
+		window:    window,
+	}
+}
+
+func (r *RateLimiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		// Normalize remote address to IP only (strip port) when possible
+		ip := req.RemoteAddr
+		if host, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+			ip = host
+		}
+
+		// Reset if window expired
+		if time.Now().After(r.resetTime) {
+			r.requests = make(map[string]int)
+			r.resetTime = time.Now().Add(r.window)
+		}
+
+		r.requests[ip]++
+
+		if r.requests[ip] > r.limit {
+			http.Error(w, "Too many requests, please try again later.", http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, req)
+	})
+}
+
+// RateLimiter is a convenience wrapper so router code can call authMiddleware.RateLimiter(limit)
+// It returns a middleware that enforces `limit` requests per 1 minute window.
+func RateLimiter(limit int) func(http.Handler) http.Handler {
+	rl := NewRateLimiter(limit, time.Minute)
+	return rl.Middleware
+}

--- a/server/router/router.go
+++ b/server/router/router.go
@@ -8,10 +8,10 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 
-	coreHandler "chat-application/internal/api/handler/core"
-	statsHandler "chat-application/internal/api/handler/stats"
-	userHandler "chat-application/internal/api/handler/user"
-	authMiddleware "chat-application/middleware"
+	coreHandler "chat-application/server/internal/api/handler/core"
+	statsHandler "chat-application/server/internal/api/handler/stats"
+	userHandler "chat-application/server/internal/api/handler/user"
+	authMiddleware "chat-application/server/internal/middleware"
 )
 
 func SetupRoutes(userHandler *userHandler.UserHandler, coreHandler *coreHandler.CoreHandler, statsHandler *statsHandler.StatsHandler) http.Handler {
@@ -70,6 +70,8 @@ func SetupRoutes(userHandler *userHandler.UserHandler, coreHandler *coreHandler.
 		api.Route("/websoc", func(u chi.Router)  {
 			u.Group(func(r chi.Router)  {
 				r.Use(authMiddleware.OptionalJWTAuth)
+				// Apply a stricter per-route rate limiter to prevent room-creation spam
+				r.Use(authMiddleware.RateLimiter(10)) // 10 requests per minute for creating rooms
 				r.Post("/create-room", coreHandler.CreateRoom)
 			})
 


### PR DESCRIPTION
Add route-level rate limiting to prevent spam and API abuse.
Applied stricter limits to auth endpoints (/api/users/sign-up, /api/users/login) and to room creation (POST /api/websoc/create-room).
Added RateLimiter(limit int) helper and IP normalization in [ratelimiter.go](vscode-file://vscode-app/c:/Users/diksh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Fixed imports to match [go.mod](vscode-file://vscode-app/c:/Users/diksh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Files changed (brief)

[ratelimiter.go](vscode-file://vscode-app/c:/Users/diksh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — wrapper + IP normalization
[router.go](vscode-file://vscode-app/c:/Users/diksh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — per-route limiter for create-room
[main.go](vscode-file://vscode-app/c:/Users/diksh/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — import fixes
Quick test

Hit the endpoints repeatedly and expect HTTP 429 after exceeding the configured limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added rate limiting to API endpoints. Room creation is now limited to 10 requests per minute. Requests exceeding this limit will return a 429 Too Many Requests response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->